### PR TITLE
qt5: Fix qt full #40706

### DIFF
--- a/pkgs/development/libraries/qt-5/5.10/default.nix
+++ b/pkgs/development/libraries/qt-5/5.10/default.nix
@@ -37,7 +37,7 @@ let
   srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
 
   patches = {
-    qtbase = [ ./qtbase.patch ] ++
+    qtbase = [ ./qtbase.patch ./qtbase2.patch ] ++
       optionals stdenv.isDarwin [ ./qtbase-darwin.patch
                                   ./restore-pc-files.patch ];
     qtdeclarative = [ ./qtdeclarative.patch ];

--- a/pkgs/development/libraries/qt-5/5.10/qtbase2.patch
+++ b/pkgs/development/libraries/qt-5/5.10/qtbase2.patch
@@ -1,0 +1,30 @@
+diff --git a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+index 0bbc871..3673634 100644
+--- a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
++++ b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+@@ -286,7 +286,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+     macro(_populate_$${CMAKE_MODULE_NAME}_plugin_properties Plugin Configuration PLUGIN_LOCATION)
+         set_property(TARGET Qt5::${Plugin} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+ 
+-        set(imported_location \"$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
++        set(imported_location \"${PLUGIN_LOCATION}\")
+         _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
+         set_target_properties(Qt5::${Plugin} PROPERTIES
+             \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
+diff --git a/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in b/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+index 5baf0fd..3583745 100644
+--- a/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
++++ b/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+@@ -2,10 +2,10 @@
+ add_library(Qt5::$$CMAKE_PLUGIN_NAME MODULE IMPORTED)
+ 
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"$${CMAKE_PLUGIN_DIR}$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
+ !!ENDIF
+ !!IF !isEmpty(CMAKE_DEBUG_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"$${CMAKE_PLUGIN_DIR}$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
+ !!ENDIF
+ 
+ list(APPEND Qt5$${CMAKE_MODULE_NAME}_PLUGINS Qt5::$$CMAKE_PLUGIN_NAME)


### PR DESCRIPTION
Fixing the code that generates cmake files for Qt5Gui plugins. They had
a wrong absolute path pointing to qt5gui instead of the plugin store
path.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

